### PR TITLE
Errores en SDP de INVITE

### DIFF
--- a/uaserver.py
+++ b/uaserver.py
@@ -74,9 +74,9 @@ class EchoHandler(SocketServer.DatagramRequestHandler):
                      " " + IP + '\n' + "s=misesion" + '\n' + "t=0" + '\n' +
                      "m=audio " + cHandler.rtpaudio_puerto + " RTP")
             MensajesLog(envio)
-            SDP = ("Content-Type: application/sdp" + '\r\n' + "v=0" + '\n' +
-                   "o=" + cHandler.account_username + " " + IP + '\n' +
-                   "s=misesion" + '\n' + "t=0" + '\n' + "m=audio " +
+            SDP = ("Content-Type: application/sdp" + '\r\n\r\n' + "v=0" + '\r\n' +
+                   "o=" + cHandler.account_username + " " + IP + '\r\n' +
+                   "s=misesion" + '\r\n' + "t=0" + '\r\n' + "m=audio " +
                    cHandler.rtpaudio_puerto + " RTP")
             self.wfile.write("SIP/2.0 100 Trying" + '\r\n\r\n' +
                              "SIP/2.0 180 Ringing" + '\r\n\r\n' +


### PR DESCRIPTION
Hola Miriam. El SDP escrito correctamente tiene \r\n\r\n después del content-type y \r\n después de los demás campos no solo \n como tu tenias.
Necesitas la correspondiente modificación el el cliente para que funcione.
Un saludo, Javier
